### PR TITLE
depend on v1.0.0 of zend-search, not on dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.*",
-        "excelwebzone/zend-search": "dev-master"
+        "excelwebzone/zend-search": "v1.0.0"
     },
     "autoload": {
         "psr-0": { "EWZ\\Bundle\\SearchBundle": "" }


### PR DESCRIPTION
Hi Michael,

can you please update the composer.json and tag the new version of this bundle with v1.0.1.

The way it is now, we still depend on dev-master because of the version in this composer.json file.

Thanks a lot in advance,
Dominik